### PR TITLE
whiteboard: fix json URL computation.

### DIFF
--- a/whiteboard/whiteboard.js
+++ b/whiteboard/whiteboard.js
@@ -786,7 +786,7 @@ var RevealWhiteboard = (function(){
      */
     function annotationURL()
     {
-        var url = location.href;
+        var url = location.origin + location.pathname;
         var basename = url.substring(0, url.lastIndexOf("."));
 
         // decker filenames vs. Mario filenames


### PR DESCRIPTION
The old code assumed no dot (.) would appear in the anchor portion of
the URL.  Example that broke this assumption:
http://localhost:8000/test.html#/plot.ly-test